### PR TITLE
Fix background color variable

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -1,3 +1,7 @@
+# Global color settings for prompt
+set -g background_color "1"
+set -g fours_color "81"
+
 function fish_prompt --description 'Write out the prompt'
   if [ $status -eq 0 ]
   else


### PR DESCRIPTION
## Summary
- set global color variables in `fish_prompt.fish`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854afbe98f4832b8041aa08f426229b