### PR TITLE
Fix tmux clipboard on Linux

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -2,6 +2,9 @@
 set -g default-command /usr/bin/fish
 set -g default-shell /usr/bin/fish
 
+# Detect clipboard command for copy mode
+if-shell 'command -v pbcopy >/dev/null 2>&1' "set-option -g @copy_cmd 'pbcopy'" "set-option -g @copy_cmd 'xclip -selection clipboard'"
+
 # tmuxを256色表示できるようにする
 set-option -g default-terminal "screen-256color"
 set-option -sa terminal-overrides ',xterm-256color:Tc'
@@ -60,13 +63,13 @@ bind-key -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if 
 bind-key -n WheelDownPane select-pane -t= \; send-keys -M
 
 # マウス操作でドラッグしたらbufferにコピーするし、clipboardにも保存する
-bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
 
 # set-option -g default-command "exec reattach-to-user-namespace -l fish"
 setw -g mode-keys vi
 bind-key -T copy-mode-vi v     send-keys -X begin-selection
-bind-key -T copy-mode-vi y     send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
-bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi y     send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
+bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "#{@copy_cmd}"
 
 # コピーモードでvimキーバインドを使う
 setw -g mode-keys vi


### PR DESCRIPTION
## Summary
- support automatic clipboard command detection in tmux
- use that clipboard command for mouse selection and copy

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6854b17605f4832bb3286e5891adeffa