### PR TITLE
リンクコマンド実行前に確認を追加

### DIFF
--- a/link.sh
+++ b/link.sh
@@ -3,11 +3,22 @@ set -e
 
 DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-ln -sf "$DOTFILES_DIR/fish_prompt.fish" ~/.config/fish/functions/fish_prompt.fish
-ln -sf "$DOTFILES_DIR/ide" ~/.shellscript/ide
-ln -sf "$DOTFILES_DIR/dein_lazy.toml" ~/.config/nvim/dein_lazy.toml
-ln -sf "$DOTFILES_DIR/dein.toml" ~/.config/nvim/dein.toml
-ln -sf "$DOTFILES_DIR/init.vim" ~/.config/nvim/init.vim
-ln -sf "$DOTFILES_DIR/.tmux.conf" ~/.tmux.conf
-ln -sf "$DOTFILES_DIR/.hyper.js" ~/.hyper.js
-ln -sf "$DOTFILES_DIR/config.fish" ~/.config/fish/config.fish
+confirm_and_run() {
+    local cmd="$1"
+    echo "$cmd"
+    read -p "Execute this command? [y/N] " -r
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        eval "$cmd"
+    else
+        echo "Skipped: $cmd"
+    fi
+}
+
+confirm_and_run "ln -sf \"$DOTFILES_DIR/fish_prompt.fish\" ~/.config/fish/functions/fish_prompt.fish"
+confirm_and_run "ln -sf \"$DOTFILES_DIR/ide\" ~/.shellscript/ide"
+confirm_and_run "ln -sf \"$DOTFILES_DIR/dein_lazy.toml\" ~/.config/nvim/dein_lazy.toml"
+confirm_and_run "ln -sf \"$DOTFILES_DIR/dein.toml\" ~/.config/nvim/dein.toml"
+confirm_and_run "ln -sf \"$DOTFILES_DIR/init.vim\" ~/.config/nvim/init.vim"
+confirm_and_run "ln -sf \"$DOTFILES_DIR/.tmux.conf\" ~/.tmux.conf"
+confirm_and_run "ln -sf \"$DOTFILES_DIR/.hyper.js\" ~/.hyper.js"
+confirm_and_run "ln -sf \"$DOTFILES_DIR/config.fish\" ~/.config/fish/config.fish"


### PR DESCRIPTION
## 概要
`link.sh` で各リンクコマンドを実行する前に確認を求めるようにしました。これにより、意図しないファイル上書きを防ぎつつ必要な処理だけを選択できます。

## 変更点
- `confirm_and_run` 関数を追加し、コマンド実行前に `y/N` で確認
- 既存のリンク処理をすべてこの関数経由で実行するよう更新


------
https://chatgpt.com/codex/tasks/task_e_6861df1245f4832b981d90adb1f697a0