### PR TITLE
link.sh: ディレクトリがない場合に自動作成するよう修正

### DIFF
--- a/link.sh
+++ b/link.sh
@@ -14,11 +14,20 @@ confirm_and_run() {
     fi
 }
 
-confirm_and_run "ln -sf \"$DOTFILES_DIR/fish_prompt.fish\" ~/.config/fish/functions/fish_prompt.fish"
-confirm_and_run "ln -sf \"$DOTFILES_DIR/ide\" ~/.shellscript/ide"
-confirm_and_run "ln -sf \"$DOTFILES_DIR/dein_lazy.toml\" ~/.config/nvim/dein_lazy.toml"
-confirm_and_run "ln -sf \"$DOTFILES_DIR/dein.toml\" ~/.config/nvim/dein.toml"
-confirm_and_run "ln -sf \"$DOTFILES_DIR/init.vim\" ~/.config/nvim/init.vim"
-confirm_and_run "ln -sf \"$DOTFILES_DIR/.tmux.conf\" ~/.tmux.conf"
-confirm_and_run "ln -sf \"$DOTFILES_DIR/.hyper.js\" ~/.hyper.js"
-confirm_and_run "ln -sf \"$DOTFILES_DIR/config.fish\" ~/.config/fish/config.fish"
+link_file() {
+    local src="$1"
+    local dest="$2"
+    local dest_dir
+    dest_dir="$(dirname "$dest")"
+    mkdir -p "$dest_dir"
+    confirm_and_run "ln -sf \"$src\" \"$dest\""
+}
+
+link_file "$DOTFILES_DIR/fish_prompt.fish" "$HOME/.config/fish/functions/fish_prompt.fish"
+link_file "$DOTFILES_DIR/ide" "$HOME/.shellscript/ide"
+link_file "$DOTFILES_DIR/dein_lazy.toml" "$HOME/.config/nvim/dein_lazy.toml"
+link_file "$DOTFILES_DIR/dein.toml" "$HOME/.config/nvim/dein.toml"
+link_file "$DOTFILES_DIR/init.vim" "$HOME/.config/nvim/init.vim"
+link_file "$DOTFILES_DIR/.tmux.conf" "$HOME/.tmux.conf"
+link_file "$DOTFILES_DIR/.hyper.js" "$HOME/.hyper.js"
+link_file "$DOTFILES_DIR/config.fish" "$HOME/.config/fish/config.fish"


### PR DESCRIPTION
## 概要
`ln` 実行時に対象ディレクトリが存在しないと失敗していたため、リンク前にディレクトリを作成する `link_file` 関数を追加しました。

## テスト結果
- `bash -n link.sh`
- `shellcheck` は環境に存在しなかったため実行できませんでした。

------
https://chatgpt.com/codex/tasks/task_e_6861e2c72c38832bb77d36e594419ef8